### PR TITLE
GWAS Catalog ingestion

### DIFF
--- a/1_make_tables.Snakefile
+++ b/1_make_tables.Snakefile
@@ -14,46 +14,24 @@ from snakemake.remote.FTP import RemoteProvider as FTPRemoteProvider
 from snakemake.remote.GS import RemoteProvider as GSRemoteProvider
 from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
 
-
 # Load configuration
 configfile: "configs/config.yaml"
 tmpdir = config['temp_dir']
 KEEP_LOCAL = False
 
-if 'version' not in config:
-    config['version'] = date.today().strftime("%y%m%d")
-
-targets = []
-
-# Make targets for top loci table
-targets.append(
-    'output/{version}/toploci.parquet'.format(version=config['version']) )
-
-# Make targets for study table
-targets.append(
-    'output/{version}/studies.parquet'.format(version=config['version']) )
-
-# Make targets for study table
-targets.append(
-    'output/{version}/trait_efo.parquet'.format(version=config['version']) )
-
-# Make targets for finemapping table
-targets.append(
-    'output/{version}/finemapping.parquet'.format(version=config['version']) )
-
-# Make targets for LD input table
-targets.append(
-    'output/{version}/ld_analysis_input.tsv'.format(version=config['version']) )
-
-# Make trait to EFO lut table
-targets.append(
-    'output/{version}/trait_efo.parquet'.format(version=config['version']) )
+# Extract run version from configuration if exists:
+version = config['version'] if 'version' not in config else date.today().strftime("%y%m%d")
 
 # Trigger making of targets
 rule all:
-    input:
-        targets
-    log: f"logs/{config['version']}/1_make_tables.log"
+    input:  
+        f'output/{version}/toploci.parquet'  # Make targets for top loci table
+        f'output/{version}/studies.parquet'  # Make targets for study table
+        f'output/{version}/trait_efo.parquet'  # Make targets for study table
+        f'output/{version}/finemapping.parquet'  # Make targets for finemapping table
+        f'output/{version}/ld_analysis_input.tsv'  # Make targets for LD input table
+        f'output/{version}/trait_efo.parquet'  # Make trait to EFO lut table
+    log: f"logs/{version}/1_make_tables.log"
 
 # Add workflows
 include: 'snakefiles/study_and_top_loci_tables.Snakefile'

--- a/1_make_tables.Snakefile
+++ b/1_make_tables.Snakefile
@@ -20,7 +20,7 @@ tmpdir = config['temp_dir']
 KEEP_LOCAL = False
 
 # Extract run version from configuration if exists:
-version = config['version'] if 'version' not in config else date.today().strftime("%y%m%d")
+version = config['version'] if 'version' in config else date.today().strftime('%y%m%d')
 
 # Trigger making of targets
 rule all:

--- a/scripts/extract_from_variant-index.py
+++ b/scripts/extract_from_variant-index.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# Ed Mountjoy
-#
 
-import sys
-import os
 import argparse
 import gzip
 
@@ -14,7 +8,7 @@ def main():
     # Parse args
     args = parse_args()
     allowed_chroms = set(
-        [str(x) for x  in range(1, 23)] + ['X', 'Y', 'MT']
+        [str(x) for x in range(1, 23)] + ['X', 'Y', 'MT']
     )
 
     # Load rsid and chr:pos sets from gwas catalog assocs
@@ -23,32 +17,37 @@ def main():
     # Parse vcf
     with gzip.open(args.vcf, 'r') as in_h:
         with gzip.open(args.out, 'w') as out_h:
-            in_h.readline() # Skip header
+            in_h.readline()  # Skip header
             for line in in_h:
-                
+
                 parts = line.decode().rstrip().split('\t')
-                
+
                 # Extract b37 chrom:pos
                 chrom_b37 = parts[2]
                 pos_b37 = parts[3]
                 chrom_pos_b37 = '{0}:{1}'.format(chrom_b37, pos_b37)
+
                 # Extract b38 chrom:pos
                 chrom_b38 = parts[4]
                 pos_b38 = parts[5]
                 chrom_pos_b38 = '{0}:{1}'.format(chrom_b38, pos_b38)
+
                 # Extract rsid
                 rsid = parts[8]
 
                 # Skip invalid chroms
-                if ((chrom_b37 not in allowed_chroms) or
-                    (chrom_b38 not in allowed_chroms)):
+                if (
+                    (chrom_b37 not in allowed_chroms)
+                    or (chrom_b38 not in allowed_chroms)
+                ):
                     continue
-                
-                # Write line if variant is a gwas association
-                if ((chrom_pos_b37 in chrom_pos_b37_set) or 
-                    (chrom_pos_b38 in chrom_pos_b38_set) or
-                    (rsid in rsid_set)):
 
+                # Write line if variant is a gwas association
+                if (
+                    (chrom_pos_b37 in chrom_pos_b37_set) or 
+                    (chrom_pos_b38 in chrom_pos_b38_set) or
+                    (rsid in rsid_set)
+                ):
                     out_h.write(line)
 
     return 0
@@ -71,7 +70,7 @@ def parse_sets(in_gwas):
     with open(in_gwas, 'r') as in_h:
         header = in_h.readline().rstrip().split('\t')
         for line in in_h:
-            
+
             parts = line.rstrip().split('\t')
 
             # Add rsid from SNP_ID_CURRENT to rsid set

--- a/scripts/ingest_GWAS_Catalog.py
+++ b/scripts/ingest_GWAS_Catalog.py
@@ -1,0 +1,171 @@
+### Disclarimer: this is a work in-progress version of the ingest script.
+import logging
+import sys
+
+import numpy as np
+
+import pyspark.sql
+import pyspark.sql.types as t
+import pyspark.sql.functions as f
+
+
+# Init logging:
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(module)s - %(funcName)s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+    stream=sys.stderr
+)
+
+spark = (
+    pyspark.sql.SparkSession
+    .builder
+    .master("local[*]")
+    .getOrCreate()
+)
+
+# These parameters will come as command line arguments:
+variant_annotation = 'gs://genetics-portal-dev-analysis/dsuveges/variant_annotation/2022-06-22'
+associations = 'https://www.ebi.ac.uk/gwas/api/search/downloads/alternative'  # URL to GWAS Catalog associations
+
+# These parameters will be read from a config file:
+
+
+# Ingesting GWAS Catalog associations:
+DROPPED_STUDIES = [
+    'GCST005806',  # Sun et al pQTL study
+    'GCST005837'  # Huang et al IBD study
+]
+
+# This flag will allow to run the code for PPP allowing the ingestion of unpublished studies:
+INGEST_UNPUBLISHED_STUDIES = False
+
+# P-value threshold for associations:
+PVALCUTOFF = 8e-8
+
+
+ASSOCIATION_COLUMNS_MAP = {
+    # Variant related columns:
+    'STRONGEST SNP-RISK ALLELE': 'strongest_snp_risk_allele',  # variant id and the allele is extracted (; separated list)
+    'CHR_ID': 'chr_id',  # Mapped genomic location of the variant (; separated list)
+    'CHR_POS': 'chr_pos',
+    'RISK ALLELE FREQUENCY': 'risk_allele_frequency',
+    'CNV': 'cnv',  # Flag if a variant is a copy number variant
+    'SNP_ID_CURRENT': 'snp_id_current',  #
+    'SNPS': 'snp_ids',  # List of all SNPs associated with the variant
+
+    # Study related columns:
+    'STUDY ACCESSION': 'study_accession',
+
+    # Disease/Trait related columns:
+    'DISEASE/TRAIT': 'disease_trait',  # Reported trait of the study
+    'MAPPED_TRAIT_URI': 'mapped_trait_uri',  # Mapped trait URIs of the study
+    'MERGED': 'merged',
+    'P-VALUE (TEXT)': 'p_value_text',  # Extra information on the association.
+
+    # Association details:
+    'P-VALUE': 'p_value',  # p-value of the association, string: split into exponent and mantissa.
+    'PVALUE_MLOG': 'pvalue_mlog',  # -log10(p-value) of the association, float
+    'OR or BETA': 'or_beta',  # Effect size of the association, Odds ratio or beta
+    '95% CI (TEXT)': 'confidence_interval',  # Confidence interval of the association, string: split into lower and upper bound.
+
+    'CONTEXT': 'context',
+}
+
+# Reading and filtering associations:
+association_df = (
+    spark.read.csv(associations, sep='\t', header=True)
+
+    # Select and rename columns:
+    .select(*[f.col(old_name).alias(new_name) for old_name, new_name in ASSOCIATION_COLUMNS_MAP.items()])
+
+    # Apply some pre-defined filters on the data:
+    .filter(
+        (~f.col('chr_id').contains(' x '))  # Dropping associations based on variant x variant interactions
+        & (~f.col('pvalue_mlog') >= -np.log10(PVALCUTOFF))  # Dropping sub-significant associations
+        & (f.col('chr_pos').isNotNull() & f.col('chr_id').isNotNull())  # Dropping associations without genomic location
+    )
+)
+
+# Providing stats on the filtered association dataset:
+logging.info(f'Number of associations: {association_df.count()}')
+logging.info(f'Number of studies: {association_df.select("study_accession").distinct().count()}')
+logging.info(f'Number of variants: {association_df.select("SNPS").distinct().count()}')
+logging.info(f'Assocation: {association_df.show(2, False, True)}')
+
+logging.info('Processing associaitons:')
+
+# Processing associations:
+parsed_associations = (
+
+    # spark.read.csv(associations, sep='\t', header=True)
+    association_df
+
+    # Adding association identifier for future deduplication:
+    .withColumn('association_id', f.monotonically_increasing_id())
+
+    # Processing variant related columns:
+    #   - Sorting out current rsID field:
+    #   - Removing variants with no genomic mappings -> losing ~3% of all associations
+    #   - Multiple variants can correspond to a single association.
+    #   - Variant identifiers are stored in the SNPS column, while the mapped coordinates are stored in the CHR_ID and CHR_POS columns.
+    #   - All these fields are split into arrays, then they are paired with the same index eg. first ID is paired with first coordinate, and so on
+    #   - Then the association is exploded to all variants.
+    #   - The risk allele is extracted from the 'STRONGEST SNP-RISK ALLELE' column.
+
+    # The current snp id field is just a number at the moment (stored as a string). Adding 'rs' prefix if looks good.
+    .withColumn(
+        'snp_id_current',
+        f.when(f.col('snp_id_current').rlike('^[0-9]*$'), f.format_string('rs%s', f.col('snp_id_current')))
+        .otherwise(f.col('snp_id_current'))
+    )
+
+    # Variant notation (chr, pos, snp id) are split into array:
+    .withColumn('chr_id', f.split(f.col('chr_id'), ';'))
+    .withColumn('chr_pos', f.split(f.col('chr_pos'), ';'))
+    .withColumn('strongest_snp_risk_allele', f.split(f.col('strongest_snp_risk_allele'), '; '))
+    .withColumn('snp_ids', f.split(f.col('snp_ids'), '; '))
+
+    # Variant fields are joined together in a matching list, then extracted into a separate rows again:
+    .withColumn('VARIANT', f.explode(f.arrays_zip('chr_id', 'chr_pos', 'strongest_snp_risk_allele', 'snp_ids')))
+
+    # Updating variant columns:
+    .withColumn('chr_id', f.col('VARIANT.chr_id'))
+    .withColumn('chr_pos', f.col('VARIANT.chr_pos').cast(t.IntegerType()))
+    .withColumn('strongest_snp_risk_allele', f.col('VARIANT.strongest_snp_risk_allele'))
+
+    # Extracting risk allele:
+    .withColumn('risk_allele', f.split(f.col('strongest_snp_risk_allele'), '-').getItem(1))
+
+    # Collecting all SNPs linked to the assocition:
+    .withColumn(
+        'rsid_gwas_catalog',
+        f.array(
+           f.split(f.col('strongest_snp_risk_allele'), '-').getItem(0),
+           f.col('snp_id_current'),
+           f.col('SNPS')
+        )
+    )
+
+    # Processing EFO terms:
+    #   - Multiple EFO terms can correspond to a single association.
+    #   - EFO terms are stored as full URIS, separated by semicolons.
+    #   - Associations are exploded to all EFO terms.
+    #   - EFO terms in the study table is not considered as association level EFO annotation has priority (via p-value text)
+
+    # Process EFO URIs:
+    .withColumn('efo', f.explode(f.expr(r"regexp_extract_all(mapped_trait_uri, '([A-Z]+_[0-9]+)')")))
+
+    # Splitting p-value into exponent and mantissa:
+    .withColumn('exponent', f.split(f.col('p_value'), 'E').getItem(1).cast('integer'))
+    .withColumn('mantissa', f.split(f.col('p_value'), 'E').getItem(0).cast('float'))
+
+    # Cleaning up:
+    .drop('mapped_trait_uri', 'strongest_snp_risk_allele', 'VARIANT')
+)
+
+# Providing stats on the filtered association dataset:
+logging.info(f'Number of associations: {parsed_associations.count()}')
+logging.info(f'Number of studies: {parsed_associations.select("study_accession").distinct().count()}')
+logging.info(f'Number of variants: {parsed_associations.select("SNPS").distinct().count()}')
+logging.info(f'Assocation: {parsed_associations.show(2, False, True)}')

--- a/scripts/ingest_GWAS_Catalog.py
+++ b/scripts/ingest_GWAS_Catalog.py
@@ -5,30 +5,18 @@ import sys
 import numpy as np
 
 import pyspark.sql
+from pyspark.sql import DataFrame
 import pyspark.sql.types as t
 import pyspark.sql.functions as f
 from pyspark import SparkFiles
 
 
-# Init logging:
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s %(module)s - %(funcName)s: %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-    stream=sys.stderr
-)
 
-spark = (
-    pyspark.sql.SparkSession
-    .builder
-    .master("local[*]")
-    .getOrCreate()
-)
 
 # These parameters will come as command line arguments:
-variant_annotation = 'gs://genetics-portal-dev-analysis/dsuveges/variant_annotation/2022-06-22'
+VARIANT_ANNOTATION = 'gs://genetics-portal-dev-analysis/dsuveges/variant_annotation/2022-06-22'
 # associations = 'https://www.ebi.ac.uk/gwas/api/search/downloads/alternative'  # URL to GWAS Catalog associations
-associations = 'gs://ot-team/dsuveges/v2d_files/gwas_associations_2022-06-27.tsv'
+GWAS_CATALOG_ASSOCIATIONS = 'gs://ot-team/dsuveges/v2d_files/gwas_associations_2022-06-27.tsv'
 
 ##
 ## Temporary output files:
@@ -49,7 +37,6 @@ INGEST_UNPUBLISHED_STUDIES = False
 
 # P-value threshold for associations:
 PVALCUTOFF = 8e-8
-
 
 ASSOCIATION_COLUMNS_MAP = {
     # Variant related columns:
@@ -79,132 +66,175 @@ ASSOCIATION_COLUMNS_MAP = {
     'CONTEXT': 'context',
 }
 
-# Reading and filtering associations:
-association_df = (
-    spark.read.csv(associations, sep='\t', header=True)
 
-    # Select and rename columns:
-    .select(*[f.col(old_name).alias(new_name) for old_name, new_name in ASSOCIATION_COLUMNS_MAP.items()])
+def read_GWAS_associations() -> DataFrame:
+    '''This function retrieves the GWAS Catalog association dataset'''
 
-    # Cast columns:
-    .withColumn('pvalue_mlog', f.col('pvalue_mlog').cast(t.FloatType()))
+    # Reading and filtering associations:
+    association_df = (
+        spark.read.csv(GWAS_CATALOG_ASSOCIATIONS, sep='\t', header=True)
 
-    # Apply some pre-defined filters on the data:
-    .filter(
-        (~f.col('chr_id').contains(' x '))  # Dropping associations based on variant x variant interactions
-        & (f.col('pvalue_mlog') > -np.log10(PVALCUTOFF))  # Dropping sub-significant associations
-        & (f.col('chr_pos').isNotNull() & f.col('chr_id').isNotNull())  # Dropping associations without genomic location
-    )
-)
+        # Select and rename columns:
+        .select(*[f.col(old_name).alias(new_name) for old_name, new_name in ASSOCIATION_COLUMNS_MAP.items()])
 
-# Providing stats on the filtered association dataset:
-logging.info(f'Number of associations: {association_df.count()}')
-logging.info(f'Number of studies: {association_df.select("study_accession").distinct().count()}')
-logging.info(f'Number of variants: {association_df.select("snp_ids").distinct().count()}')
-logging.info(f'Assocation: {association_df.show(2, False, True)}')
+        # Cast columns:
+        .withColumn('pvalue_mlog', f.col('pvalue_mlog').cast(t.FloatType()))
 
-logging.info('Processing associaitons:')
-
-# Processing associations:
-parsed_associations = (
-
-    # spark.read.csv(associations, sep='\t', header=True)
-    association_df
-
-    # Adding association identifier for future deduplication:
-    .withColumn('association_id', f.monotonically_increasing_id())
-
-    # Processing variant related columns:
-    #   - Sorting out current rsID field:
-    #   - Removing variants with no genomic mappings -> losing ~3% of all associations
-    #   - Multiple variants can correspond to a single association.
-    #   - Variant identifiers are stored in the SNPS column, while the mapped coordinates are stored in the CHR_ID and CHR_POS columns.
-    #   - All these fields are split into arrays, then they are paired with the same index eg. first ID is paired with first coordinate, and so on
-    #   - Then the association is exploded to all variants.
-    #   - The risk allele is extracted from the 'STRONGEST SNP-RISK ALLELE' column.
-
-    # The current snp id field is just a number at the moment (stored as a string). Adding 'rs' prefix if looks good.
-    .withColumn(
-        'snp_id_current',
-        f.when(f.col('snp_id_current').rlike('^[0-9]*$'), f.format_string('rs%s', f.col('snp_id_current')))
-        .otherwise(f.col('snp_id_current'))
+        # Apply some pre-defined filters on the data:
+        .filter(
+            (~f.col('chr_id').contains(' x '))  # Dropping associations based on variant x variant interactions
+            & (f.col('pvalue_mlog') > -np.log10(PVALCUTOFF))  # Dropping sub-significant associations
+            & (f.col('chr_pos').isNotNull() & f.col('chr_id').isNotNull())  # Dropping associations without genomic location
+        )
     )
 
-    # Variant notation (chr, pos, snp id) are split into array:
-    .withColumn('chr_id', f.split(f.col('chr_id'), ';'))
-    .withColumn('chr_pos', f.split(f.col('chr_pos'), ';'))
-    .withColumn('strongest_snp_risk_allele', f.split(f.col('strongest_snp_risk_allele'), '; '))
-    .withColumn('snp_ids', f.split(f.col('snp_ids'), '; '))
+    # Providing stats on the filtered association dataset:
+    logging.info(f'Number of associations: {association_df.count()}')
+    logging.info(f'Number of studies: {association_df.select("study_accession").distinct().count()}')
+    logging.info(f'Number of variants: {association_df.select("snp_ids").distinct().count()}')
+    logging.info(f'Assocation: {association_df.show(2, False, True)}')
 
-    # Variant fields are joined together in a matching list, then extracted into a separate rows again:
-    .withColumn('VARIANT', f.explode(f.arrays_zip('chr_id', 'chr_pos', 'strongest_snp_risk_allele', 'snp_ids')))
+    logging.info('Processing associaitons:')
+    return association_df
 
-    # Updating variant columns:
-    .withColumn('snp_ids', f.col('VARIANT.snp_ids'))
-    .withColumn('chr_id', f.col('VARIANT.chr_id'))
-    .withColumn('chr_pos', f.col('VARIANT.chr_pos').cast(t.IntegerType()))
-    .withColumn('strongest_snp_risk_allele', f.col('VARIANT.strongest_snp_risk_allele'))
 
-    # Extracting risk allele:
-    .withColumn('risk_allele', f.split(f.col('strongest_snp_risk_allele'), '-').getItem(1))
+def parse_associations(association_df: DataFrame) -> DataFrame:
+    # Processing associations:
+    parsed_associations = (
 
-    # Create a unique set of SNPs linked to the assocition:
-    .withColumn(
-        'rsid_gwas_catalog',
-        f.array_distinct(f.array(
-           f.split(f.col('strongest_snp_risk_allele'), '-').getItem(0),
-           f.col('snp_id_current'),
-           f.col('snp_ids')
-        ))
+        # spark.read.csv(associations, sep='\t', header=True)
+        association_df
+
+        # Adding association identifier for future deduplication:
+        .withColumn('association_id', f.monotonically_increasing_id())
+
+        # Processing variant related columns:
+        #   - Sorting out current rsID field:
+        #   - Removing variants with no genomic mappings -> losing ~3% of all associations
+        #   - Multiple variants can correspond to a single association.
+        #   - Variant identifiers are stored in the SNPS column, while the mapped coordinates are stored in the CHR_ID and CHR_POS columns.
+        #   - All these fields are split into arrays, then they are paired with the same index eg. first ID is paired with first coordinate, and so on
+        #   - Then the association is exploded to all variants.
+        #   - The risk allele is extracted from the 'STRONGEST SNP-RISK ALLELE' column.
+
+        # The current snp id field is just a number at the moment (stored as a string). Adding 'rs' prefix if looks good.
+        .withColumn(
+            'snp_id_current',
+            f.when(f.col('snp_id_current').rlike('^[0-9]*$'), f.format_string('rs%s', f.col('snp_id_current')))
+            .otherwise(f.col('snp_id_current'))
+        )
+
+        # Variant notation (chr, pos, snp id) are split into array:
+        .withColumn('chr_id', f.split(f.col('chr_id'), ';'))
+        .withColumn('chr_pos', f.split(f.col('chr_pos'), ';'))
+        .withColumn('strongest_snp_risk_allele', f.split(f.col('strongest_snp_risk_allele'), '; '))
+        .withColumn('snp_ids', f.split(f.col('snp_ids'), '; '))
+
+        # Variant fields are joined together in a matching list, then extracted into a separate rows again:
+        .withColumn('VARIANT', f.explode(f.arrays_zip('chr_id', 'chr_pos', 'strongest_snp_risk_allele', 'snp_ids')))
+
+        # Updating variant columns:
+        .withColumn('snp_ids', f.col('VARIANT.snp_ids'))
+        .withColumn('chr_id', f.col('VARIANT.chr_id'))
+        .withColumn('chr_pos', f.col('VARIANT.chr_pos').cast(t.IntegerType()))
+        .withColumn('strongest_snp_risk_allele', f.col('VARIANT.strongest_snp_risk_allele'))
+
+        # Extracting risk allele:
+        .withColumn('risk_allele', f.split(f.col('strongest_snp_risk_allele'), '-').getItem(1))
+
+        # Create a unique set of SNPs linked to the assocition:
+        .withColumn(
+            'rsid_gwas_catalog',
+            f.array_distinct(f.array(
+                f.split(f.col('strongest_snp_risk_allele'), '-').getItem(0),
+                f.col('snp_id_current'),
+                f.col('snp_ids')
+            ))
+        )
+
+        # Processing EFO terms:
+        #   - Multiple EFO terms can correspond to a single association.
+        #   - EFO terms are stored as full URIS, separated by semicolons.
+        #   - Associations are exploded to all EFO terms.
+        #   - EFO terms in the study table is not considered as association level EFO annotation has priority (via p-value text)
+
+        # Process EFO URIs:
+        .withColumn('efo', f.explode(f.expr(r"regexp_extract_all(mapped_trait_uri, '([A-Z]+_[0-9]+)')")))
+
+        # Splitting p-value into exponent and mantissa:
+        .withColumn('exponent', f.split(f.col('p_value'), 'E').getItem(1).cast('integer'))
+        .withColumn('mantissa', f.split(f.col('p_value'), 'E').getItem(0).cast('float'))
+
+        # Cleaning up:
+        .drop('mapped_trait_uri', 'strongest_snp_risk_allele', 'VARIANT')
+        .persist()
     )
 
-    # Processing EFO terms:
-    #   - Multiple EFO terms can correspond to a single association.
-    #   - EFO terms are stored as full URIS, separated by semicolons.
-    #   - Associations are exploded to all EFO terms.
-    #   - EFO terms in the study table is not considered as association level EFO annotation has priority (via p-value text)
+    # Providing stats on the filtered association dataset:
+    logging.info(f'Number of associations: {parsed_associations.count()}')
+    logging.info(f'Number of studies: {parsed_associations.select("study_accession").distinct().count()}')
+    logging.info(f'Number of variants: {parsed_associations.select("snp_ids").distinct().count()}')
+    logging.info(f'Assocation: {parsed_associations.show(2, False, True)}')
 
-    # Process EFO URIs:
-    .withColumn('efo', f.explode(f.expr(r"regexp_extract_all(mapped_trait_uri, '([A-Z]+_[0-9]+)')")))
+    return parsed_associations
 
-    # Splitting p-value into exponent and mantissa:
-    .withColumn('exponent', f.split(f.col('p_value'), 'E').getItem(1).cast('integer'))
-    .withColumn('mantissa', f.split(f.col('p_value'), 'E').getItem(0).cast('float'))
+def map_associations(parsed_associations: DataFrame) -> DataFrame:
+    # Loading variant annotation and join with parsed associations:
+    logging.info('Loading variant annotation:')
 
-    # Cleaning up:
-    .drop('mapped_trait_uri', 'strongest_snp_risk_allele', 'VARIANT')
-    .persist()
-)
-
-# Providing stats on the filtered association dataset:
-logging.info(f'Number of associations: {parsed_associations.count()}')
-logging.info(f'Number of studies: {parsed_associations.select("study_accession").distinct().count()}')
-logging.info(f'Number of variants: {parsed_associations.select("snp_ids").distinct().count()}')
-logging.info(f'Assocation: {parsed_associations.show(2, False, True)}')
-
-# Saving data:
-# parsed_associations.write.mode('overwrite').parquet(f'{OUTPUT_PATH}/parsed_associations.parquet')
-
-# Loading variant annotation and join with parsed associations:
-logging.info('Loading variant annotation:')
-
-# Reading and joining variant annotation:
-variants = (
-    spark.read.parquet(variant_annotation)
-    .select(
-        f.col('chrom_b38').alias('chr_id'),
-        f.col('pos_b38').alias('chr_pos'),
-        f.col('rsid').alias('rsid_gnomad'),
-        f.col('ref').alias('ref'),
-        f.col('alt').alias('alt')
+    # Reading and joining variant annotation:
+    variants = (
+        spark.read.parquet(VARIANT_ANNOTATION)
+        .select(
+            f.col('chrom_b38').alias('chr_id'),
+            f.col('pos_b38').alias('chr_pos'),
+            f.col('rsid').alias('rsid_gnomad'),
+            f.col('ref').alias('ref'),
+            f.col('alt').alias('alt')
+        )
     )
-)
 
-mapped_associations = (
-    parsed_associations
-    .join(variants, on=['chr_id', 'chr_pos'], how='left_outer')
-    .persist()
-)
+    mapped_associations = (
+        parsed_associations
+        .join(variants, on=['chr_id', 'chr_pos'], how='left_outer')
+        .persist()
+    )
 
-mapped_associations.write.mode('overwrite').parquet(f'{OUTPUT_PATH}/mapped_parsed_associations.parquet')
+    return mapped_associations
 
+def main():
+
+    # Read GWAS associations and process:
+    gwas_associations = read_GWAS_associations()
+    parsed_gwas_associations = parse_associations(gwas_associations)
+
+    # Save data:
+    # parsed_gwas_associations.write.mode('overwrite').parquet(f'{OUTPUT_PATH}/parsed_associations.parquet')
+
+    mapped_associations = map_associations(parsed_gwas_associations)
+    # Save mapped data:
+    mapped_associations.write.mode('overwrite').parquet(f'{OUTPUT_PATH}/mapped_parsed_associations.parquet')
+
+    # Read mapped associations as debug:
+    # mapped_associations = spark.read.parquet(f'{OUTPUT_PATH}/mapped_parsed_associations.parquet')
+
+
+if __name__ == '__main__':
+    # Init logging:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(module)s - %(funcName)s: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        stream=sys.stderr
+    )
+
+    # Init spark
+    global spark
+    spark = (
+        pyspark.sql.SparkSession
+        .builder
+        .master("local[*]")
+        .getOrCreate()
+    )
+
+    main()


### PR DESCRIPTION
This is a prototype of the revisited ingestion of the GWAS Catalog data. At this stage it reads the GWAS Catalog association data, selects and parses relevant columns. Some of the logic from the original v2d pipeline is propagated but not all. 

**TODOs**:
- [x] Parse GWAS Catalog associations.
- [x] Apply p-value and other filters
- [x] Parsing snp identifiers
- [x] Parsing p-values
- [x] Join with variant annotation
- [ ] Check allele concordance
- [ ] Deduplicate variant data
- [ ] Clustering etc.

**! Warning:** as the PR is a prototype, all parameters are hardcoded. The script runs stand-alone on dataproc as a pyspark job as follows:
```bash
gcloud dataproc jobs submit pyspark   \
    --cluster=ds-single \
    --project=open-targets-eu-dev \
    --region=europe-west1 ingest_GWAS_Catalog.py 
```