### PR TITLE
V2D Traits handling bug fix

### DIFF
--- a/scripts/make_UKB_study_table.py
+++ b/scripts/make_UKB_study_table.py
@@ -90,7 +90,7 @@ def make_trait_reported_string(s_raw):
     s_raw = re.sub(r' +', r' ', s_raw)
 
     # Assert no "|" in trait name
-    assert "|" not in s_raw
+    assert "|" not in s_raw, f"Reported trait ({s_raw}), contains invalid character."
 
     # Split prefix
     parts = s_raw.split(': ', 1)

--- a/scripts/make_UKB_study_table.py
+++ b/scripts/make_UKB_study_table.py
@@ -84,7 +84,7 @@ def to_int_safe(i):
 
 
 def make_trait_reported_string(s_raw):
-    '''Takes the raw trait name and outputs trnasformed name'''
+    '''Takes the raw trait name and outputs transformed name'''
 
     # Replace any double spaces with single
     s_raw = re.sub(r' +', r' ', s_raw)
@@ -101,7 +101,7 @@ def make_trait_reported_string(s_raw):
     else:
         trait = s_raw
 
-    # Capitalise the frist letter
+    # Capitalise the first letter
     trait = trait.capitalize()
 
     return trait


### PR DESCRIPTION
This PR includes:
-  A fix in the script **that processes the UKB manifest**. The UKB studies were lacking the reported trait, and this was causing problems downstream in the release process. 
    - In a previous PR the logic that handled the trait data was moved from the study generation to a central module that processed the entirety of the traits.
    - However, there is some logic that processes the traits that cannot be removed from the module without causing downstream problems. The function `make_trait_reported_string` has been therefore brought back.

- An improvement in the script **that generates the traits LUT**. There was a problem in the traits LUT that was secondary to the one mentioned above. We were losing study-to-EFO records that we previously had, causing, again, problems downstream because EFOs are used in other parts of the pipeline like i[n L2G](https://github.com/opentargets/genetics-l2g-scoring/blob/09b7beb7793adc728b0b0c5ce683552d0fe861d9/1_feature_engineering/2_make_features/interlocus_string.py#L62).
    - The problem was happening in the process of building the most relevant therapeutic area per EFO.
    - One step of this process is to group the LUT on study/reported trait pairs and list all EFOs for that pair. The grouping function was **not null safe** and therefore was dropping all the studies where the reported trait was null.